### PR TITLE
readme update for docker hub

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -153,6 +153,13 @@ jobs:
           tags: ${{ env.DOCKER_IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: cnescatlab/docker-cat
+
   close_milestone:
     name: Close milestone
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Proposed changes

With the CD, the latest README is not updated on docker hub

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](CODE_OF_CONDUCT.md)
- [x] Lint and unit tests pass locally with my changes
- [x] Codacy validates the quality of the modifications
- [x] GitHub Actions CI workflow passes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
